### PR TITLE
check if property exists on env instead of if value exists

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -25,7 +25,7 @@ function pickPermitted(vars, opts){
 function applyVarsToEnv(vars){
   var varsSet = {}
   for (k in vars){
-    if(!process.env[k]){
+    if(!process.env.hasOwnProperty(k)){
       var val = vars[k]
       process.env[k] = val
       varsSet[k] = val


### PR DESCRIPTION
We would like to be able to override a variable which is set in envKey, and set it to undefined. The way this is done with dotenv is by setting the variable to nothing - for example: `MY_VAR=`.  
The current code is checking `if(!process.env[k])` which will disregard `MY_VAR` in our case. 
The suggested change will check if the property exists on `process.env` so it will be set correctly.