### PR TITLE
Allow absolute paths in opts.dotEnvFile

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -37,7 +37,13 @@ function applyVarsToEnv(vars){
 
 function getKey(opts){
   if (opts.dotEnvFile){
-    dotenv.load({path: "./" + opts.dotEnvFile})
+    var path = opts.dotEnvFile;
+
+    if(path.charAt(0) !== "/") {
+      path = "./" + opts.dotEnvFile;
+    }
+
+    dotenv.load({path: path})
   } else {
     dotenv.config()
   }


### PR DESCRIPTION
Don't prepend a `./` to opts.dotEnvFile if it begins with a `/` already. I understand this could technically be a breaking change if people are passing in opts.dotEnvFile parameters that begin with a `/`, though in that case the current behavior doesn't make a lot of sense anyway.

Fixes #21 